### PR TITLE
RFC: Several tweaks to the PkgEval badges

### DIFF
--- a/tools/pkgeval_badges/src/cli.js
+++ b/tools/pkgeval_badges/src/cli.js
@@ -15,9 +15,9 @@ fs.existsSync(output_dir) || fs.mkdirSync(output_dir, { recursive: true })
 
 const bf = new BadgeFactory()
 const formats = {
-    'ok':   ['success', 'green'],
-    'skip': ['skipped', 'blue'],
-    'fail': ['failed',  'red'],
+    'ok':   ['passing', 'brightgreen'],
+    'skip': ['skipped', 'gray'],
+    'fail': ['failing',  'red'],
     'kill': ['killed',  'red'],
 }
 
@@ -29,7 +29,7 @@ for (var uuid in db.tests) {
     [text, color] = formats[test.status]
 
     format = {
-        text: ['pkgeval', text],
+        text: ['PkgEval', text],
         color: color,
         template: 'flat',
     }


### PR DESCRIPTION
This pull request makes the following changes to the pkgeval badges:

1. `PkgEval` instead of `pkgeval`
2. `passing` instead of `success` to be consistent with Travis)
3.  `failing` instead of `failed` (to be consistent with Travis)
4. `gray` color for skipped packages (to be consistent with Travis color for cancelled or skipped builds)
5. `brightgreen` color for passing packages

@maleadt Let me know if you want me to separate these changes into separate pull requests.