### PR TITLE
In addition to the main badge, also create a badge with the package's name

### DIFF
--- a/tools/pkgeval_badges/src/cli.js
+++ b/tools/pkgeval_badges/src/cli.js
@@ -70,14 +70,23 @@ for (var uuid in db.tests) {
     var text, color
     [text, color] = formats[test.status]
 
-    // generate the badge
-    format = {
+    // generate the badges
+    format_main_badge = {
         text: ['PkgEval', text],
         color: color,
         template: 'flat',
     }
-    svg = bf.create(format)
-    fs.writeFileSync(path.join(badge_dir, test.name + ".svg"), svg)
+    format_named_badge = {
+        text: [test.name, text],
+        color: color,
+        template: 'flat',
+    }
+    
+    svg_main_badge = bf.create(format_main_badge)
+    svg_named_badge = bf.create(format_named_badge)
+    
+    fs.writeFileSync(path.join(badge_dir, test.name + ".svg"), svg_main_badge)
+    fs.writeFileSync(path.join(badge_dir, test.name + ".named.svg"), svg_named_badge)
 
     // generate a redirect to the log
     fs.writeFileSync(path.join(badge_dir, test.name + ".html"),


### PR DESCRIPTION
The main badge looks like this: `PkgEval | passing` or `PkgEval | failing`

This commit also adds a "named badge" that looks like this: `MyExamplePackage | passing` or `MyExamplePackage | failing`

I've always wanted something like this, i.e. a status badge that has the package's name in it. This makes it really easy to make a status dashboard of multiple packages.

Also, it prevents you from accidentally putting the wrong badge on your package's README (which I did in fact do very recently). If you put the wrong badge, you will see `PkgEval | passing` in your README, and you will think that your package is passing, when in fact it might be failing. With the default badge, it does not say the name of the package. But with the named badge, it is immediately obvious at a glance that you have the wrong badge.