### PR TITLE
Travis: do a shallow clone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ os: linux
 language: node_js
 node_js:
   - node
+  
+git:
+  depth: false
 
 script:
   - npm install tools/pkgeval_badges


### PR DESCRIPTION
Currently, the Travis job clones to a depth of 50 commits, which takes approximately 14-16 minutes for the clone alone.

Do we need to do a deep clone, or is a shallow clone sufficient? 

This PR changes Travis to do a shallow clone.

cc: @maleadt 