### PR TITLE
Document the "named badge" feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,23 @@ Use the following code to embed the PkgEval badge and a link to the latest repor
 
 The result will look as follows:
 
-[pkgeval-img]: https://juliaci.github.io/NanosoldierReports/pkgeval_badges/E/Example.svg
+[pkgeval-img-1]: https://juliaci.github.io/NanosoldierReports/pkgeval_badges/E/Example.svg
+[pkgeval-url-1]: https://juliaci.github.io/NanosoldierReports/pkgeval_badges/E/Example.html
+
+[![PkgEval][pkgeval-img-1]][pkgeval-url-1]
+
+Alternatively, you can embed a badge that includes the name of your package in the badge itself. Use the following code (changing `E/Example` to your package name, prefixed by its initial):
+
+```
+[pkgeval-img]: https://juliaci.github.io/NanosoldierReports/pkgeval_badges/E/Example.named.svg
 [pkgeval-url]: https://juliaci.github.io/NanosoldierReports/pkgeval_badges/E/Example.html
 
 [![PkgEval][pkgeval-img]][pkgeval-url]
+```
+
+The result will look as follows:
+
+[pkgeval-img-2]: https://juliaci.github.io/NanosoldierReports/pkgeval_badges/E/Example.named.svg
+[pkgeval-url-2]: https://juliaci.github.io/NanosoldierReports/pkgeval_badges/E/Example.html
+
+[![PkgEval][pkgeval-img-2]][pkgeval-url-2]


### PR DESCRIPTION
This pull request documents the new "named badge" feature that includes the package's name in the badge itself.

cc: @maleadt 